### PR TITLE
Support Julia LTS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityTestSuite"
 uuid = "feb245ec-c857-584e-a66a-22324acf10c6"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -24,7 +24,7 @@ MCMCDiagnosticTools = "0.1"
 Sobol = "1"
 StatsFuns = "0.9, 1"
 UnPack = "1"
-julia = "1.8"
+julia = "1.6"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,7 +86,7 @@ end
 
     @testset "MvNormal triangular" begin
         Σ = Symmetric(Q * D * Q')
-        A = cholesky(Σ, NoPivot()).L
+        A = cholesky(Σ).L
         test_mvnormal(μ, A, Σ)
     end
 


### PR DESCRIPTION
Since LogDensityProblems supports Julia LTS, I think it would be good to support Julia 1.6 here as well.

Tests pass locally without any additional code. I only had to remove the explicit `NoPivot` in a call of `cholesky` in the tests. Alternatively, one could use `Val(false)` on Julia < 1.8 but since `Val(false)`/`NoPivot` is the default anyway this seemed unnecessary.